### PR TITLE
feat(api): enrich monthly billing summary with cost-per-student metrics

### DIFF
--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -1,0 +1,91 @@
+import { InvoiceStatus } from '@prisma/client';
+import { BillingService } from './billing.service';
+
+describe('BillingService.getMonthlySummary', () => {
+  const prisma = {
+    billingCycle: { findUnique: jest.fn() },
+    invoice: { findMany: jest.fn() },
+    expense: { aggregate: jest.fn() },
+    contract: { findMany: jest.fn() },
+  } as any;
+
+  const audit = {
+    log: jest.fn(),
+  } as any;
+
+  const service = new BillingService(prisma, audit);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('retorna resumo zerado quando não existe ciclo', async () => {
+    prisma.billingCycle.findUnique.mockResolvedValue(null);
+
+    const result = await service.getMonthlySummary('tenant-1', 2026, 4);
+
+    expect(result.totalExpected).toBe(0);
+    expect(result.totalPaid).toBe(0);
+    expect(result.totalPending).toBe(0);
+    expect(result.overdueCount).toBe(0);
+    expect(result.expenseTotal).toBe(0);
+    expect(result.activeChildren).toBe(0);
+    expect(result.costPerChild).toBe(0);
+    expect(result.comparison).toEqual({
+      expectedDelta: 0,
+      paidDelta: 0,
+      pendingDelta: 0,
+      overdueDelta: 0,
+      expenseDelta: 0,
+      costPerChildDelta: 0,
+    });
+  });
+
+  it('calcula resumo, custo por aluno e comparação com período anterior', async () => {
+    prisma.billingCycle.findUnique
+      .mockResolvedValueOnce({ id: 'cycle-current' })
+      .mockResolvedValueOnce({ id: 'cycle-previous' });
+
+    prisma.invoice.findMany
+      .mockResolvedValueOnce([
+        { total: 1000, paidAmount: 600, dueDate: new Date('2026-04-10'), status: InvoiceStatus.PENDING },
+        { total: 500, paidAmount: 500, dueDate: new Date('2026-04-01'), status: InvoiceStatus.PAID },
+      ])
+      .mockResolvedValueOnce([
+        { total: 900, paidAmount: 700, dueDate: new Date('2026-03-10'), status: InvoiceStatus.PAID },
+      ]);
+
+    prisma.expense.aggregate
+      .mockResolvedValueOnce({ _sum: { amount: 300 } })
+      .mockResolvedValueOnce({ _sum: { amount: 200 } });
+
+    prisma.contract.findMany
+      .mockResolvedValueOnce([{ childId: 'a' }, { childId: 'b' }])
+      .mockResolvedValueOnce([{ childId: 'a' }]);
+
+    const result = await service.getMonthlySummary('tenant-1', 2026, 4);
+
+    expect(result.totalExpected).toBe(1500);
+    expect(result.totalPaid).toBe(1100);
+    expect(result.totalPending).toBe(400);
+    expect(result.expenseTotal).toBe(300);
+    expect(result.activeChildren).toBe(2);
+    expect(result.costPerChild).toBe(150);
+
+    expect(result.previous.totalExpected).toBe(900);
+    expect(result.previous.totalPaid).toBe(700);
+    expect(result.previous.totalPending).toBe(200);
+    expect(result.previous.expenseTotal).toBe(200);
+    expect(result.previous.activeChildren).toBe(1);
+    expect(result.previous.costPerChild).toBe(200);
+
+    expect(result.comparison).toEqual({
+      expectedDelta: 600,
+      paidDelta: 400,
+      pendingDelta: 200,
+      overdueDelta: 1,
+      expenseDelta: 100,
+      costPerChildDelta: -50,
+    });
+  });
+});

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -122,22 +122,80 @@ export class BillingService {
   }
 
   async getMonthlySummary(tenantId: string, year: number, month: number) {
-    const cycle = await this.prisma.billingCycle.findUnique({
-      where: { tenantId_year_month: { tenantId, year, month } },
-    });
-    if (!cycle) return { totalExpected: 0, totalPaid: 0, totalPending: 0, overdueCount: 0 };
+    const buildSummary = async (refYear: number, refMonth: number) => {
+      const cycle = await this.prisma.billingCycle.findUnique({
+        where: { tenantId_year_month: { tenantId, year: refYear, month: refMonth } },
+      });
+      if (!cycle) {
+        return {
+          totalExpected: 0,
+          totalPaid: 0,
+          totalPending: 0,
+          overdueCount: 0,
+          expenseTotal: 0,
+          activeChildren: 0,
+          costPerChild: 0,
+        };
+      }
 
-    const invoices = await this.prisma.invoice.findMany({
-      where: { billingCycleId: cycle.id },
-    });
-    const totalExpected = invoices.reduce((s, i) => s + Number(i.total), 0);
-    const totalPaid = invoices.reduce((s, i) => s + Number(i.paidAmount), 0);
-    const totalPending = totalExpected - totalPaid;
-    const overdueCount = invoices.filter(
-      (i) => i.status === InvoiceStatus.OVERDUE || (i.status === InvoiceStatus.PENDING && new Date(i.dueDate) < new Date()),
-    ).length;
+      const invoices = await this.prisma.invoice.findMany({
+        where: { billingCycleId: cycle.id },
+      });
 
-    return { totalExpected, totalPaid, totalPending, overdueCount };
+      const totalExpected = invoices.reduce((s, i) => s + Number(i.total), 0);
+      const totalPaid = invoices.reduce((s, i) => s + Number(i.paidAmount), 0);
+      const totalPending = totalExpected - totalPaid;
+      const overdueCount = invoices.filter(
+        (i) => i.status === InvoiceStatus.OVERDUE || (i.status === InvoiceStatus.PENDING && new Date(i.dueDate) < new Date()),
+      ).length;
+
+      const monthStart = new Date(refYear, refMonth - 1, 1, 0, 0, 0, 0);
+      const monthEnd = new Date(refYear, refMonth, 0, 23, 59, 59, 999);
+
+      const expenses = await this.prisma.expense.aggregate({
+        _sum: { amount: true },
+        where: {
+          tenantId,
+          date: { gte: monthStart, lte: monthEnd },
+        },
+      });
+
+      const activeContracts = await this.prisma.contract.findMany({
+        where: {
+          tenantId,
+          startDate: { lte: monthEnd },
+          OR: [{ endDate: null }, { endDate: { gte: monthStart } }],
+        },
+        select: { childId: true },
+        distinct: ['childId'],
+      });
+
+      const expenseTotal = Number(expenses._sum.amount || 0);
+      const activeChildren = activeContracts.length;
+      const costPerChild = activeChildren > 0 ? expenseTotal / activeChildren : 0;
+
+      return { totalExpected, totalPaid, totalPending, overdueCount, expenseTotal, activeChildren, costPerChild };
+    };
+
+    const current = await buildSummary(year, month);
+
+    const previousDate = new Date(year, month - 2, 1);
+    const previous = await buildSummary(previousDate.getFullYear(), previousDate.getMonth() + 1);
+
+    const comparison = {
+      expectedDelta: current.totalExpected - previous.totalExpected,
+      paidDelta: current.totalPaid - previous.totalPaid,
+      pendingDelta: current.totalPending - previous.totalPending,
+      overdueDelta: current.overdueCount - previous.overdueCount,
+      expenseDelta: current.expenseTotal - previous.expenseTotal,
+      costPerChildDelta: current.costPerChild - previous.costPerChild,
+    };
+
+    return {
+      ...current,
+      previous,
+      comparison,
+    };
   }
 
   /**


### PR DESCRIPTION
## Entrega\n- resumo mensal financeiro agora inclui:\n  - expenseTotal\n  - activeChildren\n  - costPerChild\n  - previous (mês anterior)\n  - comparison deltas\n- testes unitários de BillingService cobrindo cenário sem ciclo e com comparação\n\n## Validação\n- pnpm --filter api test -- --runInBand --verbose\n- pnpm --filter api lint\n- pnpm --filter api build\n- pnpm --filter web lint\n- pnpm --filter web build