### PR TITLE
feat(api): webhook Asaas idempotente para baixa automática

### DIFF
--- a/apps/api/src/payments/payments.controller.ts
+++ b/apps/api/src/payments/payments.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Headers, Post, UnauthorizedException, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { FinancialAccess } from '../auth/decorators/rbac-groups.decorator';
@@ -6,6 +6,7 @@ import { FinancialAccess } from '../auth/decorators/rbac-groups.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { PaymentsService } from './payments.service';
 import { CreatePaymentDto } from './dto/create-payment.dto';
+import { Public } from '../auth/decorators/public.decorator';
 
 @ApiTags('Pagamentos')
 @ApiBearerAuth()
@@ -32,5 +33,19 @@ export class PaymentsController {
       dto.reference,
       dto.notes,
     );
+  }
+
+  @Public()
+  @Post('webhooks/asaas')
+  receiveAsaasWebhook(
+    @Headers('x-webhook-token') token: string | undefined,
+    @Body() payload: any,
+  ) {
+    const expected = process.env.ASAAS_WEBHOOK_TOKEN;
+    if (expected && token !== expected) {
+      throw new UnauthorizedException('Invalid webhook token');
+    }
+
+    return this.paymentsService.processAsaasWebhook(payload);
   }
 }

--- a/apps/api/src/payments/payments.service.spec.ts
+++ b/apps/api/src/payments/payments.service.spec.ts
@@ -1,0 +1,82 @@
+import { PaymentsService } from './payments.service';
+
+describe('PaymentsService (Asaas webhook)', () => {
+  const prisma: any = {
+    payment: { findFirst: jest.fn() },
+    invoice: { findFirst: jest.fn() },
+  };
+  const audit = { log: jest.fn() } as any;
+
+  let service: PaymentsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PaymentsService(prisma, audit);
+  });
+
+  it('ignora evento que não representa pagamento recebido', async () => {
+    const result = await service.processAsaasWebhook({
+      id: 'evt_1',
+      event: 'INVOICE_CREATED',
+      payment: {},
+    });
+
+    expect(result).toEqual({ processed: false, reason: 'event_not_supported' });
+    expect(prisma.invoice.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('evita duplicidade quando referência do evento já foi processada', async () => {
+    prisma.payment.findFirst.mockResolvedValueOnce({ id: 'pay_existing' });
+
+    const result = await service.processAsaasWebhook({
+      id: 'evt_dup',
+      event: 'PAYMENT_RECEIVED',
+      payment: {
+        id: 'pay_asaas_1',
+        value: 130,
+        billingType: 'PIX',
+        paymentDate: '2026-04-28',
+        externalReference: 'inv_123',
+      },
+    });
+
+    expect(result).toEqual({ processed: false, reason: 'duplicate_event' });
+  });
+
+  it('registra pagamento quando webhook válido chega pela primeira vez', async () => {
+    prisma.payment.findFirst.mockResolvedValueOnce(null);
+    prisma.invoice.findFirst.mockResolvedValueOnce({
+      id: 'inv_123',
+      tenantId: 'tenant_1',
+    });
+
+    const registerSpy = jest
+      .spyOn(service, 'register')
+      .mockResolvedValue({ id: 'inv_123', status: 'PAID' } as any);
+
+    const result = await service.processAsaasWebhook({
+      id: 'evt_ok',
+      event: 'PAYMENT_RECEIVED',
+      payment: {
+        id: 'pay_asaas_1',
+        value: 130,
+        billingType: 'PIX',
+        paymentDate: '2026-04-28',
+        externalReference: 'inv_123',
+      },
+    });
+
+    expect(registerSpy).toHaveBeenCalledWith(
+      'tenant_1',
+      undefined,
+      'inv_123',
+      130,
+      'PIX',
+      expect.any(Date),
+      'evt_ok',
+      'Asaas paymentId=pay_asaas_1',
+    );
+
+    expect(result).toEqual({ processed: true, invoiceId: 'inv_123' });
+  });
+});

--- a/apps/api/src/payments/payments.service.ts
+++ b/apps/api/src/payments/payments.service.ts
@@ -12,6 +12,72 @@ export class PaymentsService {
     private audit: AuditService,
   ) {}
 
+  private mapAsaasBillingTypeToMethod(billingType?: string) {
+    switch ((billingType || '').toUpperCase()) {
+      case 'PIX':
+        return 'PIX';
+      case 'BOLETO':
+        return 'BOLETO';
+      case 'CREDIT_CARD':
+      case 'DEBIT_CARD':
+        return 'CARD';
+      case 'BANK_TRANSFER':
+      case 'TRANSFER':
+        return 'TRANSFER';
+      default:
+        return 'OTHER';
+    }
+  }
+
+  async processAsaasWebhook(payload: any) {
+    if (payload?.event !== 'PAYMENT_RECEIVED') {
+      return { processed: false, reason: 'event_not_supported' as const };
+    }
+
+    const eventId = payload?.id;
+    const payment = payload?.payment || {};
+    const invoiceId = payment?.externalReference;
+
+    if (!eventId || !invoiceId) {
+      return { processed: false, reason: 'missing_required_data' as const };
+    }
+
+    const duplicated = await this.prisma.payment.findFirst({
+      where: { reference: eventId },
+      select: { id: true },
+    });
+
+    if (duplicated) {
+      return { processed: false, reason: 'duplicate_event' as const };
+    }
+
+    const invoice = await this.prisma.invoice.findFirst({
+      where: { id: invoiceId },
+      select: { id: true, tenantId: true },
+    });
+
+    if (!invoice) {
+      return { processed: false, reason: 'invoice_not_found' as const };
+    }
+
+    const amount = Number(payment?.value || 0);
+    const paidAt = payment?.paymentDate ? new Date(payment.paymentDate) : new Date();
+    const method = this.mapAsaasBillingTypeToMethod(payment?.billingType);
+
+    await this.register(
+      invoice.tenantId,
+      undefined,
+      invoice.id,
+      amount,
+      method,
+      paidAt,
+      eventId,
+      `Asaas paymentId=${payment?.id || 'unknown'}`,
+    );
+
+    return { processed: true, invoiceId: invoice.id };
+  }
+
   async register(
     tenantId: string,
     userId: string | undefined,


### PR DESCRIPTION
## O que foi feito
- Adiciona endpoint público: POST /payments/webhooks/asaas
- Valida token via header x-webhook-token quando ASAAS_WEBHOOK_TOKEN estiver definido
- Processa apenas evento PAYMENT_RECEIVED
- Idempotência por payment.reference = eventId
- Baixa automática da fatura via PaymentsService.register

## Segurança
- Sem token configurado: endpoint aceita payload (modo dev)
- Com token configurado: rejeita token inválido com 401

## Qualidade
- Testes unitários cobrindo evento não suportado, duplicidade e processamento válido
- api test/lint/build e web lint/build verdes