### PR TITLE
feat(api): tratar estorno/cancelamento no webhook Asaas

### DIFF
--- a/apps/api/src/payments/payments.service.spec.ts
+++ b/apps/api/src/payments/payments.service.spec.ts
@@ -3,7 +3,7 @@ import { PaymentsService } from './payments.service';
 describe('PaymentsService (Asaas webhook)', () => {
   const prisma: any = {
     payment: { findFirst: jest.fn() },
-    invoice: { findFirst: jest.fn() },
+    invoice: { findFirst: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
   };
   const audit = { log: jest.fn() } as any;
 
@@ -77,6 +77,27 @@ describe('PaymentsService (Asaas webhook)', () => {
       'Asaas paymentId=pay_asaas_1',
     );
 
-    expect(result).toEqual({ processed: true, invoiceId: 'inv_123' });
+    expect(result).toEqual({ processed: true, invoiceId: 'inv_123', action: 'received' });
+  });
+
+  it('reabre a fatura ao receber evento de estorno', async () => {
+    prisma.payment.findFirst.mockResolvedValueOnce(null);
+    prisma.invoice.findFirst.mockResolvedValueOnce({ id: 'inv_123', tenantId: 'tenant_1' });
+    prisma.invoice.findUnique.mockResolvedValueOnce({
+      id: 'inv_123',
+      total: 200,
+      paidAmount: 200,
+      status: 'PAID',
+    });
+    prisma.invoice.update.mockResolvedValueOnce({ id: 'inv_123' });
+
+    const result = await service.processAsaasWebhook({
+      id: 'evt_refund',
+      event: 'PAYMENT_REFUNDED',
+      payment: { externalReference: 'inv_123', value: 200 },
+    });
+
+    expect(prisma.invoice.update).toHaveBeenCalled();
+    expect(result).toEqual({ processed: true, invoiceId: 'inv_123', action: 'reverted' });
   });
 });

--- a/apps/api/src/payments/payments.service.ts
+++ b/apps/api/src/payments/payments.service.ts
@@ -30,7 +30,10 @@ export class PaymentsService {
   }
 
   async processAsaasWebhook(payload: any) {
-    if (payload?.event !== 'PAYMENT_RECEIVED') {
+    const supportedEvents = new Set(['PAYMENT_RECEIVED', 'PAYMENT_REFUNDED', 'PAYMENT_DELETED']);
+    const event = payload?.event;
+
+    if (!supportedEvents.has(event)) {
       return { processed: false, reason: 'event_not_supported' as const };
     }
 
@@ -60,6 +63,53 @@ export class PaymentsService {
       return { processed: false, reason: 'invoice_not_found' as const };
     }
 
+    if (event === 'PAYMENT_REFUNDED' || event === 'PAYMENT_DELETED') {
+      const current = await this.prisma.invoice.findUnique({
+        where: { id: invoice.id },
+        select: { paidAmount: true, total: true },
+      });
+
+      if (!current) {
+        return { processed: false, reason: 'invoice_not_found' as const };
+      }
+
+      const refundAmount = new Decimal(Number(payment?.value || 0));
+      const newPaidAmount = new Decimal(current.paidAmount).sub(refundAmount);
+      const clampedPaid = newPaidAmount.lessThan(0) ? new Decimal(0) : newPaidAmount;
+      const status = clampedPaid.greaterThanOrEqualTo(new Decimal(current.total))
+        ? InvoiceStatus.PAID
+        : clampedPaid.greaterThan(0)
+          ? InvoiceStatus.PARTIAL
+          : InvoiceStatus.PENDING;
+
+      await this.prisma.invoice.update({
+        where: { id: invoice.id },
+        data: {
+          paidAmount: clampedPaid,
+          status,
+          paidAt: status === InvoiceStatus.PAID ? undefined : null,
+        },
+      });
+
+      await this.audit.log({
+        tenantId: invoice.tenantId,
+        userId: undefined,
+        action: 'UPDATE',
+        entity: 'Invoice',
+        entityId: invoice.id,
+        newData: {
+          source: 'asaas',
+          event,
+          eventId,
+          refundAmount: Number(refundAmount),
+          paidAmount: Number(clampedPaid),
+          status,
+        },
+      });
+
+      return { processed: true, invoiceId: invoice.id, action: 'reverted' as const };
+    }
+
     const amount = Number(payment?.value || 0);
     const paidAt = payment?.paymentDate ? new Date(payment.paymentDate) : new Date();
     const method = this.mapAsaasBillingTypeToMethod(payment?.billingType);
@@ -75,7 +125,7 @@ export class PaymentsService {
       `Asaas paymentId=${payment?.id || 'unknown'}`,
     );
 
-    return { processed: true, invoiceId: invoice.id };
+    return { processed: true, invoiceId: invoice.id, action: 'received' as const };
   }
 
   async register(


### PR DESCRIPTION
## O que foi feito
- Expande processamento do webhook Asaas para eventos:
  - PAYMENT_RECEIVED
  - PAYMENT_REFUNDED
  - PAYMENT_DELETED
- Em eventos de estorno/cancelamento:
  - reduz paidAmount da fatura (com clamp mínimo em 0)
  - recalcula status (PAID/PARTIAL/PENDING)
  - limpa paidAt quando fatura deixa de estar quitada
  - grava trilha de auditoria
- Mantém idempotência por eventId (payment.reference)

## Qualidade
- Teste novo cobrindo reabertura da fatura em estorno
- Suite completa verde (api test/lint/build + web lint/build)
