### PR TITLE
feat(api): relatório de conciliação financeira por ciclo

### DIFF
--- a/apps/api/src/billing/billing.controller.ts
+++ b/apps/api/src/billing/billing.controller.ts
@@ -64,4 +64,17 @@ export class BillingController {
   ) {
     return this.billingService.getOverdueReport(tenantId, referenceMonth);
   }
+
+  @Get('reconciliation')
+  getReconciliation(
+    @CurrentUser('tenantId') tenantId: string,
+    @Query('year') year: string,
+    @Query('month') month: string,
+  ) {
+    return this.billingService.getReconciliationReport(
+      tenantId,
+      parseInt(year, 10),
+      parseInt(month, 10),
+    );
+  }
 }

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -5,6 +5,7 @@ describe('BillingService.getMonthlySummary', () => {
   const prisma = {
     billingCycle: { findUnique: jest.fn() },
     invoice: { findMany: jest.fn() },
+    payment: { findMany: jest.fn() },
     expense: { aggregate: jest.fn() },
     contract: { findMany: jest.fn() },
   } as any;
@@ -86,6 +87,65 @@ describe('BillingService.getMonthlySummary', () => {
       overdueDelta: 1,
       expenseDelta: 100,
       costPerChildDelta: -50,
+    });
+  });
+});
+
+describe('BillingService.getReconciliationReport', () => {
+  const prisma = {
+    billingCycle: { findUnique: jest.fn() },
+    invoice: { findMany: jest.fn() },
+  } as any;
+  const audit = { log: jest.fn() } as any;
+  const service = new BillingService(prisma, audit);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('retorna payload vazio quando ciclo não existe', async () => {
+    prisma.billingCycle.findUnique.mockResolvedValue(null);
+
+    const result = await service.getReconciliationReport('tenant-1', 2026, 4);
+
+    expect(result.summary.totalInvoices).toBe(0);
+    expect(result.summary.expectedTotal).toBe(0);
+    expect(result.summary.invoicePaidTotal).toBe(0);
+    expect(result.summary.paymentsTotal).toBe(0);
+    expect(result.divergentInvoices).toEqual([]);
+  });
+
+  it('aponta divergências entre paidAmount da fatura e soma dos pagamentos', async () => {
+    prisma.billingCycle.findUnique.mockResolvedValue({ id: 'cycle-1' });
+    prisma.invoice.findMany.mockResolvedValue([
+      {
+        id: 'inv-1',
+        child: { name: 'Ana' },
+        status: InvoiceStatus.PAID,
+        total: 100,
+        paidAmount: 100,
+        payments: [{ amount: 100, reference: 'evt-1' }],
+      },
+      {
+        id: 'inv-2',
+        child: { name: 'Bia' },
+        status: InvoiceStatus.PARTIAL,
+        total: 200,
+        paidAmount: 150,
+        payments: [{ amount: 120, reference: null }],
+      },
+    ]);
+
+    const result = await service.getReconciliationReport('tenant-1', 2026, 4);
+
+    expect(result.summary.totalInvoices).toBe(2);
+    expect(result.summary.expectedTotal).toBe(300);
+    expect(result.summary.invoicePaidTotal).toBe(250);
+    expect(result.summary.paymentsTotal).toBe(220);
+    expect(result.summary.paidVsPaymentsDelta).toBe(30);
+    expect(result.summary.divergentCount).toBe(1);
+    expect(result.divergentInvoices[0]).toMatchObject({
+      invoiceId: 'inv-2',
+      childName: 'Bia',
+      delta: 30,
     });
   });
 });

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -267,6 +267,76 @@ export class BillingService {
     return updated;
   }
 
+  async getReconciliationReport(tenantId: string, year: number, month: number) {
+    const cycle = await this.prisma.billingCycle.findUnique({
+      where: { tenantId_year_month: { tenantId, year, month } },
+    });
+
+    if (!cycle) {
+      return {
+        summary: {
+          totalInvoices: 0,
+          expectedTotal: 0,
+          invoicePaidTotal: 0,
+          paymentsTotal: 0,
+          paidVsPaymentsDelta: 0,
+          divergentCount: 0,
+        },
+        divergentInvoices: [],
+        invoices: [],
+      };
+    }
+
+    const invoices = await this.prisma.invoice.findMany({
+      where: { tenantId, billingCycleId: cycle.id },
+      include: {
+        child: true,
+        payments: true,
+      },
+      orderBy: { dueDate: 'asc' },
+    });
+
+    const parsedInvoices = invoices.map((inv) => {
+      const expected = Number(inv.total);
+      const invoicePaid = Number(inv.paidAmount);
+      const paymentsTotal = inv.payments.reduce((sum, pay) => sum + Number(pay.amount), 0);
+      const delta = Number((invoicePaid - paymentsTotal).toFixed(2));
+
+      return {
+        invoiceId: inv.id,
+        childId: inv.childId,
+        childName: inv.child?.name ?? '',
+        status: inv.status,
+        dueDate: inv.dueDate,
+        expected,
+        invoicePaid,
+        paymentsTotal,
+        delta,
+        paymentCount: inv.payments.length,
+      };
+    });
+
+    const expectedTotal = parsedInvoices.reduce((sum, i) => sum + i.expected, 0);
+    const invoicePaidTotal = parsedInvoices.reduce((sum, i) => sum + i.invoicePaid, 0);
+    const paymentsTotal = parsedInvoices.reduce((sum, i) => sum + i.paymentsTotal, 0);
+    const paidVsPaymentsDelta = Number((invoicePaidTotal - paymentsTotal).toFixed(2));
+
+    const divergentInvoices = parsedInvoices.filter((i) => Math.abs(i.delta) >= 0.01);
+
+    return {
+      summary: {
+        totalInvoices: parsedInvoices.length,
+        expectedTotal,
+        invoicePaidTotal,
+        paymentsTotal,
+        paidVsPaymentsDelta,
+        divergentCount: divergentInvoices.length,
+      },
+      divergentInvoices,
+      invoices: parsedInvoices,
+    };
+  }
+
   async getOverdueReport(tenantId: string, referenceMonth?: string) {
     const ref = referenceMonth ? new Date(referenceMonth) : new Date();
     const refYear = ref.getFullYear();


### PR DESCRIPTION
## O que foi feito
- Novo endpoint financeiro: `GET /billing/reconciliation?year=YYYY&month=MM`
- Retorna relatório de conciliação do ciclo:
  - total esperado
  - total pago no campo da fatura (`paidAmount`)
  - soma real dos pagamentos vinculados
  - delta global entre os dois
  - lista de faturas divergentes (por fatura)
- Mantém visão completa de todas as faturas com campos de conciliação

## Regras
- Se o ciclo não existir: retorna payload vazio e consistente
- Divergência por fatura usa comparação com tolerância de centavos (`>= 0.01`)

## Qualidade
- Testes unitários novos em `billing.service.spec.ts`
- Suite completa verde (`api test/lint/build` + `web lint/build`)
