### PR TITLE
feat(finance): ação de reconciliar fatura no painel

### DIFF
--- a/apps/api/src/billing/billing.controller.ts
+++ b/apps/api/src/billing/billing.controller.ts
@@ -77,4 +77,13 @@ export class BillingController {
       parseInt(month, 10),
     );
   }
+
+  @Post('reconciliation/reconcile-invoice')
+  reconcileInvoice(
+    @CurrentUser('tenantId') tenantId: string,
+    @CurrentUser('sub') userId: string,
+    @Body() body: { invoiceId: string },
+  ) {
+    return this.billingService.reconcileInvoice(tenantId, body.invoiceId, userId);
+  }
 }

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -94,7 +94,7 @@ describe('BillingService.getMonthlySummary', () => {
 describe('BillingService.getReconciliationReport', () => {
   const prisma = {
     billingCycle: { findUnique: jest.fn() },
-    invoice: { findMany: jest.fn() },
+    invoice: { findMany: jest.fn(), findFirst: jest.fn(), update: jest.fn(), findUnique: jest.fn() },
   } as any;
   const audit = { log: jest.fn() } as any;
   const service = new BillingService(prisma, audit);
@@ -146,6 +146,40 @@ describe('BillingService.getReconciliationReport', () => {
       invoiceId: 'inv-2',
       childName: 'Bia',
       delta: 30,
+    });
+  });
+
+  it('reconcilia uma fatura ajustando paidAmount para a soma de pagamentos', async () => {
+    prisma.invoice.findFirst.mockResolvedValue({
+      id: 'inv-2',
+      tenantId: 'tenant-1',
+      paidAmount: 150,
+      total: 200,
+      payments: [{ amount: 120 }],
+    });
+    prisma.invoice.update.mockResolvedValue({
+      id: 'inv-2',
+      paidAmount: 120,
+      status: InvoiceStatus.PARTIAL,
+    });
+
+    const result = await service.reconcileInvoice('tenant-1', 'inv-2', 'user-1');
+
+    expect(prisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'inv-2' },
+        data: expect.objectContaining({
+          paidAmount: 120,
+          status: InvoiceStatus.PARTIAL,
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      invoiceId: 'inv-2',
+      previousPaidAmount: 150,
+      reconciledPaidAmount: 120,
+      deltaApplied: -30,
+      status: InvoiceStatus.PARTIAL,
     });
   });
 });

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -337,6 +337,64 @@ export class BillingService {
     };
   }
 
+  async reconcileInvoice(tenantId: string, invoiceId: string, userId?: string) {
+    const invoice = await this.prisma.invoice.findFirst({
+      where: { id: invoiceId, tenantId },
+      include: { payments: true },
+    });
+
+    if (!invoice) {
+      throw new Error('Fatura não encontrada');
+    }
+
+    const previousPaidAmount = Number(invoice.paidAmount);
+    const paymentsTotal = invoice.payments.reduce((sum, p) => sum + Number(p.amount), 0);
+    const reconciledPaidAmount = Number(paymentsTotal.toFixed(2));
+    const total = Number(invoice.total);
+
+    const status =
+      reconciledPaidAmount >= total
+        ? InvoiceStatus.PAID
+        : reconciledPaidAmount > 0
+          ? InvoiceStatus.PARTIAL
+          : new Date(invoice.dueDate) < new Date()
+            ? InvoiceStatus.OVERDUE
+            : InvoiceStatus.PENDING;
+
+    await this.prisma.invoice.update({
+      where: { id: invoiceId },
+      data: {
+        paidAmount: reconciledPaidAmount,
+        status,
+        paidAt: status === InvoiceStatus.PAID ? invoice.paidAt || new Date() : null,
+      },
+    });
+
+    await this.audit.log({
+      tenantId,
+      userId,
+      action: 'BILLING_RECONCILE_INVOICE',
+      entity: 'Invoice',
+      entityId: invoiceId,
+      oldData: {
+        paidAmount: previousPaidAmount,
+        status: invoice.status,
+      },
+      newData: {
+        paidAmount: reconciledPaidAmount,
+        status,
+      },
+    });
+
+    return {
+      invoiceId,
+      previousPaidAmount,
+      reconciledPaidAmount,
+      deltaApplied: Number((reconciledPaidAmount - previousPaidAmount).toFixed(2)),
+      status,
+    };
+  }
+
   async getOverdueReport(tenantId: string, referenceMonth?: string) {
     const ref = referenceMonth ? new Date(referenceMonth) : new Date();
     const refYear = ref.getFullYear();

--- a/apps/web/src/app/dashboard/financeiro/page.tsx
+++ b/apps/web/src/app/dashboard/financeiro/page.tsx
@@ -139,6 +139,7 @@ export default function FinanceiroPage() {
                   <th className="p-3 text-left">Pago na fatura</th>
                   <th className="p-3 text-left">Soma de pagamentos</th>
                   <th className="p-3 text-left">Delta</th>
+                  <th className="p-3 text-left">Ação</th>
                 </tr>
               </thead>
               <tbody>
@@ -149,6 +150,26 @@ export default function FinanceiroPage() {
                     <td className="p-3 lk-text-number">{fmt(row.invoicePaid)}</td>
                     <td className="p-3 lk-text-number">{fmt(row.paymentsTotal)}</td>
                     <td className="p-3 lk-text-number" style={{ color: 'var(--brand-danger)' }}>{fmt(row.delta)}</td>
+                    <td className="p-3">
+                      <button
+                        className="btn btn-secondary text-sm py-1"
+                        onClick={async () => {
+                          setUiError('');
+                          try {
+                            await apiPost('/billing/reconciliation/reconcile-invoice', { invoiceId: row.invoiceId });
+                            await Promise.all([
+                              refetchReconciliation(),
+                              refetchInvoices(),
+                              refetchSummary(),
+                            ]);
+                          } catch (err: any) {
+                            setUiError(err?.message || 'Falha ao reconciliar fatura.');
+                          }
+                        }}
+                      >
+                        Reconciliar
+                      </button>
+                    </td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
## O que foi feito
- Novo endpoint: `POST /billing/reconciliation/reconcile-invoice`
  - input: `{ invoiceId }`
  - ação: recalcula `paidAmount` da fatura pela soma real dos pagamentos vinculados
  - recalcula status (`PAID`, `PARTIAL`, `PENDING`, `OVERDUE`)
  - grava auditoria (`BILLING_RECONCILE_INVOICE`)
  - retorna delta aplicado

- Dashboard financeiro:
  - adiciona botão **Reconciliar** por linha divergente
  - após reconciliar, atualiza resumo, faturas e conciliação automaticamente

## Testes
- `billing.service.spec.ts` cobriu `reconcileInvoice`
- suite geral verde (`api test/lint/build` + `web lint/build`)
