### PR TITLE
feat(finance): batch reconciliation for divergent invoices

### DIFF
--- a/apps/api/src/billing/billing.controller.ts
+++ b/apps/api/src/billing/billing.controller.ts
@@ -86,4 +86,13 @@ export class BillingController {
   ) {
     return this.billingService.reconcileInvoice(tenantId, body.invoiceId, userId);
   }
+
+  @Post('reconciliation/reconcile-all')
+  reconcileAll(
+    @CurrentUser('tenantId') tenantId: string,
+    @CurrentUser('sub') userId: string,
+    @Body() body: { year: number; month: number },
+  ) {
+    return this.billingService.reconcileDivergentInvoices(tenantId, body.year, body.month, userId);
+  }
 }

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -182,4 +182,52 @@ describe('BillingService.getReconciliationReport', () => {
       status: InvoiceStatus.PARTIAL,
     });
   });
+
+  it('reconcilia todas as divergentes do ciclo e retorna resumo de execução', async () => {
+    prisma.billingCycle.findUnique.mockResolvedValue({ id: 'cycle-1' });
+    prisma.invoice.findMany.mockResolvedValue([
+      {
+        id: 'inv-1',
+        childId: 'c1',
+        dueDate: new Date('2026-04-10'),
+        status: InvoiceStatus.PAID,
+        total: 100,
+        paidAmount: 100,
+        payments: [{ amount: 100 }],
+      },
+      {
+        id: 'inv-2',
+        childId: 'c2',
+        dueDate: new Date('2026-04-10'),
+        status: InvoiceStatus.PARTIAL,
+        total: 200,
+        paidAmount: 150,
+        payments: [{ amount: 120 }],
+      },
+      {
+        id: 'inv-3',
+        childId: 'c3',
+        dueDate: new Date('2026-04-10'),
+        status: InvoiceStatus.PENDING,
+        total: 300,
+        paidAmount: 0,
+        payments: [{ amount: 50 }],
+      },
+    ]);
+
+    const result = await service.reconcileDivergentInvoices('tenant-1', 2026, 4, 'user-1');
+
+    expect(result).toMatchObject({
+      year: 2026,
+      month: 4,
+      totalInvoices: 3,
+      divergentCount: 2,
+      reconciledCount: 2,
+      unchangedCount: 1,
+      totalDeltaApplied: 20,
+    });
+    expect(result.reconciledInvoices).toHaveLength(2);
+    expect(prisma.invoice.update).toHaveBeenCalledTimes(2);
+    expect(audit.log).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -395,6 +395,106 @@ export class BillingService {
     };
   }
 
+  async reconcileDivergentInvoices(tenantId: string, year: number, month: number, userId?: string) {
+    const cycle = await this.prisma.billingCycle.findUnique({
+      where: { tenantId_year_month: { tenantId, year, month } },
+    });
+
+    if (!cycle) {
+      return {
+        year,
+        month,
+        totalInvoices: 0,
+        divergentCount: 0,
+        reconciledCount: 0,
+        unchangedCount: 0,
+        totalDeltaApplied: 0,
+        reconciledInvoices: [],
+      };
+    }
+
+    const invoices = await this.prisma.invoice.findMany({
+      where: { tenantId, billingCycleId: cycle.id },
+      include: { payments: true },
+      orderBy: { dueDate: 'asc' },
+    });
+
+    let totalDeltaApplied = 0;
+    const reconciledInvoices: Array<{
+      invoiceId: string;
+      previousPaidAmount: number;
+      reconciledPaidAmount: number;
+      deltaApplied: number;
+      status: InvoiceStatus;
+    }> = [];
+
+    for (const invoice of invoices) {
+      const previousPaidAmount = Number(invoice.paidAmount);
+      const paymentsTotal = invoice.payments.reduce((sum, p) => sum + Number(p.amount), 0);
+      const reconciledPaidAmount = Number(paymentsTotal.toFixed(2));
+      const deltaApplied = Number((reconciledPaidAmount - previousPaidAmount).toFixed(2));
+
+      if (Math.abs(deltaApplied) < 0.01) {
+        continue;
+      }
+
+      const total = Number(invoice.total);
+      const status =
+        reconciledPaidAmount >= total
+          ? InvoiceStatus.PAID
+          : reconciledPaidAmount > 0
+            ? InvoiceStatus.PARTIAL
+            : new Date(invoice.dueDate) < new Date()
+              ? InvoiceStatus.OVERDUE
+              : InvoiceStatus.PENDING;
+
+      await this.prisma.invoice.update({
+        where: { id: invoice.id },
+        data: {
+          paidAmount: reconciledPaidAmount,
+          status,
+          paidAt: status === InvoiceStatus.PAID ? invoice.paidAt || new Date() : null,
+        },
+      });
+
+      await this.audit.log({
+        tenantId,
+        userId,
+        action: 'BILLING_RECONCILE_INVOICE',
+        entity: 'Invoice',
+        entityId: invoice.id,
+        oldData: {
+          paidAmount: previousPaidAmount,
+          status: invoice.status,
+        },
+        newData: {
+          paidAmount: reconciledPaidAmount,
+          status,
+        },
+      });
+
+      totalDeltaApplied += deltaApplied;
+      reconciledInvoices.push({
+        invoiceId: invoice.id,
+        previousPaidAmount,
+        reconciledPaidAmount,
+        deltaApplied,
+        status,
+      });
+    }
+
+    return {
+      year,
+      month,
+      totalInvoices: invoices.length,
+      divergentCount: reconciledInvoices.length,
+      reconciledCount: reconciledInvoices.length,
+      unchangedCount: invoices.length - reconciledInvoices.length,
+      totalDeltaApplied: Number(totalDeltaApplied.toFixed(2)),
+      reconciledInvoices,
+    };
+  }
+
   async getOverdueReport(tenantId: string, referenceMonth?: string) {
     const ref = referenceMonth ? new Date(referenceMonth) : new Date();
     const refYear = ref.getFullYear();

--- a/apps/web/src/app/dashboard/financeiro/page.tsx
+++ b/apps/web/src/app/dashboard/financeiro/page.tsx
@@ -109,9 +109,26 @@ export default function FinanceiroPage() {
       <div className="lk-card">
         <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
           <h2 className="font-semibold">Conciliação financeira ({month}/{year})</h2>
-          <button className="btn btn-secondary" onClick={() => refetchReconciliation()}>
-            Atualizar
-          </button>
+          <div className="flex items-center gap-2 flex-wrap">
+            <button
+              className="btn btn-primary"
+              onClick={async () => {
+                setUiError('');
+                try {
+                  await apiPost('/billing/reconciliation/reconcile-all', { year, month });
+                  await Promise.all([refetchReconciliation(), refetchInvoices(), refetchSummary()]);
+                } catch (err: any) {
+                  setUiError(err?.message || 'Falha ao reconciliar todas as faturas divergentes.');
+                }
+              }}
+              disabled={(reconciliation?.summary.divergentCount ?? 0) === 0}
+            >
+              Reconciliar todas
+            </button>
+            <button className="btn btn-secondary" onClick={() => refetchReconciliation()}>
+              Atualizar
+            </button>
+          </div>
         </div>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">


### PR DESCRIPTION
## Resumo
- adiciona endpoint `POST /billing/reconciliation/reconcile-all` para reconciliar todas as faturas divergentes da competência
- implementa `reconcileDivergentInvoices(tenantId, year, month, userId?)` no serviço de billing
- mantém regra de status por fatura (`PAID`, `PARTIAL`, `PENDING`, `OVERDUE`) e auditoria por item reconciliado
- adiciona botão **Reconciliar todas** no painel financeiro para execução em lote com refresh dos dados

## Testes
- `pnpm --filter api test -- --runInBand --verbose apps/api/src/billing/billing.service.spec.ts`
- `pnpm --filter api lint`
- `pnpm --filter api build`
- `pnpm --filter web lint`
- `pnpm --filter web build`

## Resultado esperado
- operação financeira mais rápida para corrigir divergências em lote
- redução de trabalho manual linha a linha na conciliação
