### PR TITLE
feat(finance): add reconciliation history trail

### DIFF
--- a/apps/api/src/billing/billing.controller.ts
+++ b/apps/api/src/billing/billing.controller.ts
@@ -78,6 +78,21 @@ export class BillingController {
     );
   }
 
+  @Get('reconciliation/history')
+  getReconciliationHistory(
+    @CurrentUser('tenantId') tenantId: string,
+    @Query('year') year: string,
+    @Query('month') month: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.billingService.getReconciliationHistory(
+      tenantId,
+      parseInt(year, 10),
+      parseInt(month, 10),
+      limit ? parseInt(limit, 10) : 20,
+    );
+  }
+
   @Post('reconciliation/reconcile-invoice')
   reconcileInvoice(
     @CurrentUser('tenantId') tenantId: string,

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -95,6 +95,7 @@ describe('BillingService.getReconciliationReport', () => {
   const prisma = {
     billingCycle: { findUnique: jest.fn() },
     invoice: { findMany: jest.fn(), findFirst: jest.fn(), update: jest.fn(), findUnique: jest.fn() },
+    auditLog: { findMany: jest.fn() },
   } as any;
   const audit = { log: jest.fn() } as any;
   const service = new BillingService(prisma, audit);
@@ -229,5 +230,32 @@ describe('BillingService.getReconciliationReport', () => {
     expect(result.reconciledInvoices).toHaveLength(2);
     expect(prisma.invoice.update).toHaveBeenCalledTimes(2);
     expect(audit.log).toHaveBeenCalledTimes(2);
+  });
+
+  it('retorna histórico de reconciliação por competência', async () => {
+    prisma.auditLog.findMany.mockResolvedValue([
+      {
+        id: 'log-1',
+        createdAt: new Date('2026-04-29T10:00:00Z'),
+        userId: 'user-1',
+        entityId: 'inv-2',
+        oldData: { paidAmount: 150, status: 'PARTIAL' },
+        newData: { paidAmount: 120, status: 'PARTIAL' },
+      },
+    ]);
+
+    const result = await service.getReconciliationHistory('tenant-1', 2026, 4, 10);
+
+    expect(prisma.auditLog.findMany).toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: 'log-1',
+        createdAt: new Date('2026-04-29T10:00:00Z'),
+        userId: 'user-1',
+        invoiceId: 'inv-2',
+        oldData: { paidAmount: 150, status: 'PARTIAL' },
+        newData: { paidAmount: 120, status: 'PARTIAL' },
+      },
+    ]);
   });
 });

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -495,6 +495,30 @@ export class BillingService {
     };
   }
 
+  async getReconciliationHistory(tenantId: string, year: number, month: number, limit = 20) {
+    const start = new Date(year, month - 1, 1, 0, 0, 0, 0);
+    const end = new Date(year, month, 0, 23, 59, 59, 999);
+
+    const logs = await this.prisma.auditLog.findMany({
+      where: {
+        tenantId,
+        action: 'BILLING_RECONCILE_INVOICE',
+        createdAt: { gte: start, lte: end },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: Math.min(Math.max(limit, 1), 100),
+    });
+
+    return logs.map((log) => ({
+      id: log.id,
+      createdAt: log.createdAt,
+      userId: log.userId,
+      invoiceId: log.entityId,
+      oldData: log.oldData,
+      newData: log.newData,
+    }));
+  }
+
   async getOverdueReport(tenantId: string, referenceMonth?: string) {
     const ref = referenceMonth ? new Date(referenceMonth) : new Date();
     const refYear = ref.getFullYear();

--- a/apps/web/src/app/dashboard/financeiro/page.tsx
+++ b/apps/web/src/app/dashboard/financeiro/page.tsx
@@ -26,6 +26,15 @@ type ReconciliationRow = {
   delta: number;
 };
 
+type ReconciliationHistoryRow = {
+  id: string;
+  createdAt: string;
+  userId?: string;
+  invoiceId?: string;
+  oldData?: { paidAmount?: number; status?: string };
+  newData?: { paidAmount?: number; status?: string };
+};
+
 export default function FinanceiroPage() {
   const [paymentModal, setPaymentModal] = useState<{ invoiceId: string; total: number } | null>(null);
   const [paymentAmount, setPaymentAmount] = useState('');
@@ -53,6 +62,12 @@ export default function FinanceiroPage() {
       apiGet<{ summary: ReconciliationSummary; divergentInvoices: ReconciliationRow[] }>(
         `/billing/reconciliation?year=${year}&month=${month}`,
       ),
+  });
+
+  const { data: reconciliationHistory, refetch: refetchReconciliationHistory } = useQuery({
+    queryKey: ['billing-reconciliation-history', year, month],
+    queryFn: () =>
+      apiGet<ReconciliationHistoryRow[]>(`/billing/reconciliation/history?year=${year}&month=${month}&limit=20`),
   });
 
   const { data: invoices, isLoading, isError: invoicesError, refetch: refetchInvoices } = useQuery({
@@ -116,7 +131,12 @@ export default function FinanceiroPage() {
                 setUiError('');
                 try {
                   await apiPost('/billing/reconciliation/reconcile-all', { year, month });
-                  await Promise.all([refetchReconciliation(), refetchInvoices(), refetchSummary()]);
+                  await Promise.all([
+                    refetchReconciliation(),
+                    refetchInvoices(),
+                    refetchSummary(),
+                    refetchReconciliationHistory(),
+                  ]);
                 } catch (err: any) {
                   setUiError(err?.message || 'Falha ao reconciliar todas as faturas divergentes.');
                 }
@@ -178,6 +198,7 @@ export default function FinanceiroPage() {
                               refetchReconciliation(),
                               refetchInvoices(),
                               refetchSummary(),
+                              refetchReconciliationHistory(),
                             ]);
                           } catch (err: any) {
                             setUiError(err?.message || 'Falha ao reconciliar fatura.');
@@ -194,6 +215,46 @@ export default function FinanceiroPage() {
           </div>
         ) : (
           <p className="lk-text-muted">Sem divergências para a competência atual.</p>
+        )}
+      </div>
+
+      <div className="lk-card">
+        <div className="flex items-center justify-between gap-3 mb-3 flex-wrap">
+          <h2 className="font-semibold">Histórico de conciliações ({month}/{year})</h2>
+          <button className="btn btn-secondary" onClick={() => refetchReconciliationHistory()}>
+            Atualizar histórico
+          </button>
+        </div>
+
+        {(reconciliationHistory?.length ?? 0) > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b" style={{ borderColor: 'var(--brand-border)', color: 'var(--brand-muted)' }}>
+                  <th className="p-3 text-left">Data</th>
+                  <th className="p-3 text-left">Fatura</th>
+                  <th className="p-3 text-left">Usuário</th>
+                  <th className="p-3 text-left">Pago (antes)</th>
+                  <th className="p-3 text-left">Pago (depois)</th>
+                  <th className="p-3 text-left">Status (antes → depois)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reconciliationHistory?.map((row) => (
+                  <tr key={row.id} className="border-b" style={{ borderColor: 'var(--brand-border)' }}>
+                    <td className="p-3">{new Date(row.createdAt).toLocaleString('pt-BR')}</td>
+                    <td className="p-3 lk-text-number">{row.invoiceId ?? '-'}</td>
+                    <td className="p-3">{row.userId ?? 'sistema'}</td>
+                    <td className="p-3 lk-text-number">{fmt(Number(row.oldData?.paidAmount ?? 0))}</td>
+                    <td className="p-3 lk-text-number">{fmt(Number(row.newData?.paidAmount ?? 0))}</td>
+                    <td className="p-3">{row.oldData?.status ?? '-'} → {row.newData?.status ?? '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="lk-text-muted">Sem histórico de conciliação para esta competência.</p>
         )}
       </div>
 


### PR DESCRIPTION
## Resumo
- adiciona endpoint `GET /billing/reconciliation/history` para listar trilha de conciliações por competência
- implementa `getReconciliationHistory(tenantId, year, month, limit)` usando `AuditLog` com filtro por ação `BILLING_RECONCILE_INVOICE`
- inclui histórico no painel financeiro com data/hora, fatura, usuário, valores antes/depois e status antes/depois
- integra refresh automático do histórico após reconciliação individual e em lote

## Testes
- `pnpm --filter api test -- --runInBand --verbose apps/api/src/billing/billing.service.spec.ts`
- `pnpm --filter api lint`
- `pnpm --filter api build`
- `pnpm --filter web lint`
- `pnpm --filter web build`

## Ganho operacional
- rastreabilidade de quem executou reconciliações e quais deltas foram aplicados
- maior auditabilidade para rotina do financeiro
