### PR TITLE
feat(web): controle de acesso do módulo financeiro por perfil

### DIFF
--- a/apps/web/src/app/dashboard/financeiro/page.tsx
+++ b/apps/web/src/app/dashboard/financeiro/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiGet, apiPost } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { FINANCIAL_ROLES, hasAnyRole } from '@/lib/rbac';
 
 const now = new Date();
 
@@ -34,6 +36,8 @@ type ReconciliationHistoryRow = {
 };
 
 export default function FinanceiroPage() {
+  const { user } = useAuth();
+  const canAccessFinance = hasAnyRole(user?.roles, FINANCIAL_ROLES);
   const [selectedYear, setSelectedYear] = useState(now.getFullYear());
   const [selectedMonth, setSelectedMonth] = useState(now.getMonth() + 1);
   const [paymentModal, setPaymentModal] = useState<{ invoiceId: string; total: number } | null>(null);
@@ -96,6 +100,16 @@ export default function FinanceiroPage() {
 
   const fmt = (n: number) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(n);
   const availableYears = Array.from({ length: 6 }, (_, i) => now.getFullYear() - 3 + i);
+
+  if (!canAccessFinance) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">Financeiro</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+        <p className="lk-text-muted mt-1">Perfis com acesso: Financeiro, Administrador e Admin/CEO.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useAuth } from '@/contexts/AuthContext';
 import { useBranding } from '@/components/BrandingProvider';
+import { FINANCIAL_ROLES, hasAnyRole } from '@/lib/rbac';
 
 const nav = [
   { href: '/dashboard', label: 'Dashboard', icon: '🏠' },
@@ -20,6 +21,11 @@ const nav = [
 ];
 
 const mobileTabs = nav.slice(0, 5);
+
+function canAccessNav(href: string, userRoles: string[]) {
+  if (href === '/dashboard/financeiro') return hasAnyRole(userRoles, FINANCIAL_ROLES);
+  return true;
+}
 
 export default function DashboardLayout({
   children,
@@ -72,7 +78,7 @@ export default function DashboardLayout({
               </div>
 
               <nav className="flex-1 mt-4 space-y-1 overflow-y-auto">
-                {nav.map((item) => {
+                {nav.filter((item) => canAccessNav(item.href, user.roles)).map((item) => {
                   const active = pathname === item.href;
                   return (
                     <Link
@@ -101,7 +107,7 @@ export default function DashboardLayout({
             {children}
             <div className="lg:hidden">
               <nav className="lk-mobile-tabbar" aria-label="Ações rápidas mobile">
-                {mobileTabs.map((item) => {
+                {mobileTabs.filter((item) => canAccessNav(item.href, user.roles)).map((item) => {
                   const active = pathname === item.href;
                   return (
                     <Link key={item.href} href={item.href} className={`lk-mobile-tab ${active ? 'active' : ''}`}>

--- a/apps/web/src/lib/rbac.ts
+++ b/apps/web/src/lib/rbac.ts
@@ -1,0 +1,15 @@
+export type AppRole =
+  | 'MODERADOR'
+  | 'ADMINISTRADOR'
+  | 'ADMIN_CEO'
+  | 'COORDENACAO'
+  | 'FINANCEIRO'
+  | 'PROFESSOR'
+  | 'FUNCIONARIO';
+
+export const FINANCIAL_ROLES: AppRole[] = ['MODERADOR', 'ADMINISTRADOR', 'ADMIN_CEO', 'FINANCEIRO'];
+
+export function hasAnyRole(userRoles: string[] | undefined, requiredRoles: AppRole[]) {
+  if (!userRoles?.length) return false;
+  return requiredRoles.some((role) => userRoles.includes(role));
+}


### PR DESCRIPTION
## Objetivo
Implementar controle de visibilidade/acesso do módulo Financeiro no frontend por perfil de usuário, alinhado ao RBAC já aplicado no backend.

## O que foi feito
- adicionada utilidade de RBAC no web (`apps/web/src/lib/rbac.ts`)
- menu lateral e tabs mobile agora ocultam **Financeiro** para perfis sem acesso
- página `/dashboard/financeiro` mostra estado de **sem permissão** quando o usuário não tem role financeira

## Perfis com acesso
- MODERADOR
- ADMINISTRADOR
- ADMIN_CEO
- FINANCEIRO

## Validação
- `pnpm --filter web lint`
- `pnpm --filter web build`
- `pnpm --filter api lint`
- `pnpm --filter api test -- --runInBand --verbose src/billing/billing.service.spec.ts`
- `pnpm --filter api build`
