### PR TITLE
feat(web): completar guardas RBAC em todos os módulos do dashboard

### DIFF
--- a/apps/web/src/app/dashboard/contratos/page.tsx
+++ b/apps/web/src/app/dashboard/contratos/page.tsx
@@ -2,6 +2,8 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { apiGet } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { ACADEMIC_ROLES, hasAnyRole } from '@/lib/rbac';
 
 interface Contract {
   id: string;
@@ -13,10 +15,21 @@ interface Contract {
 }
 
 export default function ContratosPage() {
+  const { user } = useAuth();
+  const canAccess = hasAnyRole(user?.roles, ACADEMIC_ROLES);
   const { data: contracts, isLoading, isError, refetch } = useQuery({
     queryKey: ['contracts'],
     queryFn: () => apiGet<Contract[]>('/contracts'),
   });
+
+  if (!canAccess) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">Contratos</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+      </div>
+    );
+  }
 
   if (isLoading) return <p className="lk-text-muted">Carregando contratos...</p>;
 

--- a/apps/web/src/app/dashboard/coordenacao/page.tsx
+++ b/apps/web/src/app/dashboard/coordenacao/page.tsx
@@ -2,8 +2,12 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiGet, apiPatch } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { MANAGEMENT_ROLES, hasAnyRole } from '@/lib/rbac';
 
 export default function CoordenacaoPage() {
+  const { user } = useAuth();
+  const canAccess = hasAnyRole(user?.roles, MANAGEMENT_ROLES);
   const queryClient = useQueryClient();
 
   const { data: items, isLoading, isError, refetch } = useQuery({
@@ -25,6 +29,15 @@ export default function CoordenacaoPage() {
     mutationFn: (id: string) => apiPatch(`/coordination-inbox/${id}/contacted`),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['coordination-pending'] }),
   });
+
+  if (!canAccess) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">Inbox da Coordenação</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/dashboard/criancas/page.tsx
+++ b/apps/web/src/app/dashboard/criancas/page.tsx
@@ -3,10 +3,14 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiGet, apiPost, apiPut, apiDelete } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { ACADEMIC_ROLES, hasAnyRole } from '@/lib/rbac';
 
 interface Child { id: string; name: string; birthDate: string | null; class: { id: string; name: string } | null; }
 
 export default function CriancasPage() {
+  const { user } = useAuth();
+  const canAccess = hasAnyRole(user?.roles, ACADEMIC_ROLES);
   const [modal, setModal] = useState<'create' | 'edit' | null>(null);
   const [editId, setEditId] = useState<string | null>(null);
   const [name, setName] = useState('');
@@ -23,6 +27,15 @@ export default function CriancasPage() {
   const deleteMutation = useMutation({ mutationFn: (id: string) => apiDelete(`/children/${id}`), onSuccess: () => queryClient.invalidateQueries({ queryKey: ['children'] }), onError: (err: Error) => setFormError(err.message || 'Falha ao excluir criança.') });
 
   function openEdit(c: Child) { setEditId(c.id); setName(c.name); setBirthDate(c.birthDate ? c.birthDate.slice(0, 10) : ''); setClassId(c.class?.id ?? ''); setFormError(''); setModal('edit'); }
+
+  if (!canAccess) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">Alunos</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/dashboard/diario/page.tsx
+++ b/apps/web/src/app/dashboard/diario/page.tsx
@@ -3,8 +3,12 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiGet, apiPut } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { ACADEMIC_ROLES, hasAnyRole } from '@/lib/rbac';
 
 export default function DiarioPage() {
+  const { user } = useAuth();
+  const canAccess = hasAnyRole(user?.roles, ACADEMIC_ROLES);
   const [classId, setClassId] = useState('');
   const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
   const queryClient = useQueryClient();
@@ -24,6 +28,15 @@ export default function DiarioPage() {
     mutationFn: ({ id, body }: { id: string; body: any }) => apiPut(`/daily-logs/items/${id}`, body),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['daily-log'] }),
   });
+
+  if (!canAccess) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">Painel diário</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useAuth } from '@/contexts/AuthContext';
 import { useBranding } from '@/components/BrandingProvider';
-import { FINANCIAL_ROLES, hasAnyRole } from '@/lib/rbac';
+import { FINANCIAL_ROLES, hasAnyRole, MANAGEMENT_ROLES, ACADEMIC_ROLES, FULL_ACCESS_ROLES } from '@/lib/rbac';
 
 const nav = [
   { href: '/dashboard', label: 'Dashboard', icon: '🏠' },
@@ -24,6 +24,13 @@ const mobileTabs = nav.slice(0, 5);
 
 function canAccessNav(href: string, userRoles: string[]) {
   if (href === '/dashboard/financeiro') return hasAnyRole(userRoles, FINANCIAL_ROLES);
+  if (href === '/dashboard/rh' || href === '/dashboard/coordenacao' || href === '/dashboard/whatsapp') {
+    return hasAnyRole(userRoles, MANAGEMENT_ROLES);
+  }
+  if (href === '/dashboard/criancas' || href === '/dashboard/contratos' || href === '/dashboard/diario') {
+    return hasAnyRole(userRoles, ACADEMIC_ROLES);
+  }
+  if (href === '/dashboard/personalizacao') return hasAnyRole(userRoles, FULL_ACCESS_ROLES);
   return true;
 }
 

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -5,8 +5,10 @@ import Image from 'next/image';
 import { useQuery } from '@tanstack/react-query';
 import { apiGet } from '@/lib/api';
 import { useBranding } from '@/components/BrandingProvider';
+import { useAuth } from '@/contexts/AuthContext';
 import { SmartChart, type ChartPeriod } from '@/components/dashboard/SmartChart';
 import { InsightSummary } from '@/components/dashboard/InsightSummary';
+import { MANAGEMENT_ROLES, hasAnyRole } from '@/lib/rbac';
 
 interface Summary {
   billing: { totalExpected: number; totalPaid: number; totalPending: number; overdueCount: number };
@@ -23,6 +25,8 @@ function money(v: number) {
 const monthNames = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago'];
 
 export default function DashboardPage() {
+  const { user } = useAuth();
+  const canAccess = hasAnyRole(user?.roles, MANAGEMENT_ROLES);
   const { branding } = useBranding();
   const [period, setPeriod] = useState<ChartPeriod>('mes');
 
@@ -37,6 +41,15 @@ export default function DashboardPage() {
 
   const currentValue = summary?.billing.totalPaid ?? 0;
   const previousValue = summary?.billing.totalExpected ?? 1;
+
+  if (!canAccess) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">Cockpit operacional</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="grid grid-cols-1 xl:grid-cols-12 gap-4">

--- a/apps/web/src/app/dashboard/personalizacao/page.tsx
+++ b/apps/web/src/app/dashboard/personalizacao/page.tsx
@@ -4,6 +4,8 @@ import { ChangeEvent, useState } from 'react';
 import Image from 'next/image';
 import { useBranding } from '@/components/BrandingProvider';
 import { BrandingSettings, defaultBranding, isHexColor } from '@/lib/branding';
+import { useAuth } from '@/contexts/AuthContext';
+import { FULL_ACCESS_ROLES, hasAnyRole } from '@/lib/rbac';
 
 const colorFields: Array<{ key: keyof BrandingSettings['colors']; label: string }> = [
   { key: 'primary', label: 'Primária' },
@@ -17,6 +19,8 @@ const colorFields: Array<{ key: keyof BrandingSettings['colors']; label: string 
 ];
 
 export default function PersonalizacaoPage() {
+  const { user } = useAuth();
+  const canAccess = hasAnyRole(user?.roles, FULL_ACCESS_ROLES);
   const { branding, updateBranding, resetBranding } = useBranding();
   const [draft, setDraft] = useState<BrandingSettings>(branding);
   const [error, setError] = useState<string | null>(null);
@@ -38,6 +42,15 @@ export default function PersonalizacaoPage() {
     setError(null);
     updateBranding(draft);
   };
+
+  if (!canAccess) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">Personalização (whitelabel)</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/dashboard/rh/page.tsx
+++ b/apps/web/src/app/dashboard/rh/page.tsx
@@ -3,8 +3,12 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiGet, apiPost } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { MANAGEMENT_ROLES, hasAnyRole } from '@/lib/rbac';
 
 export default function RHPage() {
+  const { user } = useAuth();
+  const canAccess = hasAnyRole(user?.roles, MANAGEMENT_ROLES);
   const [staffId, setStaffId] = useState('');
   const [punchType, setPunchType] = useState<'ENTRY' | 'EXIT'>('ENTRY');
   const [geo, setGeo] = useState<{ lat: number; lng: number; accuracy?: number } | null>(null);
@@ -28,6 +32,15 @@ export default function RHPage() {
     e.preventDefault();
     if (!staffId) return;
     punchMutation.mutate({ staffProfileId: staffId, type: punchType, latitude: geo?.lat, longitude: geo?.lng, accuracy: geo?.accuracy });
+  }
+
+  if (!canAccess) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">RH</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+      </div>
+    );
   }
 
   return (

--- a/apps/web/src/app/dashboard/whatsapp/page.tsx
+++ b/apps/web/src/app/dashboard/whatsapp/page.tsx
@@ -3,8 +3,12 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiGet, apiPost } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
+import { MANAGEMENT_ROLES, hasAnyRole } from '@/lib/rbac';
 
 export default function WhatsAppPage() {
+  const { user } = useAuth();
+  const canAccess = hasAnyRole(user?.roles, MANAGEMENT_ROLES);
   const [tab, setTab] = useState<'templates' | 'rules' | 'outbox'>('outbox');
   const queryClient = useQueryClient();
 
@@ -14,6 +18,15 @@ export default function WhatsAppPage() {
 
   const processMutation = useMutation({ mutationFn: () => apiPost('/whatsapp/process-rules', {}), onSuccess: () => queryClient.invalidateQueries({ queryKey: ['whatsapp-outbox'] }) });
   const sendStubMutation = useMutation({ mutationFn: () => apiPost('/whatsapp/send-queued-stub', {}), onSuccess: () => queryClient.invalidateQueries({ queryKey: ['whatsapp-outbox'] }) });
+
+  if (!canAccess) {
+    return (
+      <div className="lk-card">
+        <h1 className="text-2xl font-bold">Comunicação (WhatsApp)</h1>
+        <p className="text-red-700 font-medium mt-2">Você não possui permissão para acessar este módulo.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/lib/rbac.ts
+++ b/apps/web/src/lib/rbac.ts
@@ -8,6 +8,16 @@ export type AppRole =
   | 'FUNCIONARIO';
 
 export const FINANCIAL_ROLES: AppRole[] = ['MODERADOR', 'ADMINISTRADOR', 'ADMIN_CEO', 'FINANCEIRO'];
+export const MANAGEMENT_ROLES: AppRole[] = ['MODERADOR', 'ADMINISTRADOR', 'ADMIN_CEO', 'COORDENACAO'];
+export const ACADEMIC_ROLES: AppRole[] = [
+  'MODERADOR',
+  'ADMINISTRADOR',
+  'ADMIN_CEO',
+  'COORDENACAO',
+  'PROFESSOR',
+  'FUNCIONARIO',
+];
+export const FULL_ACCESS_ROLES: AppRole[] = ['MODERADOR', 'ADMINISTRADOR', 'ADMIN_CEO'];
 
 export function hasAnyRole(userRoles: string[] | undefined, requiredRoles: AppRole[]) {
   if (!userRoles?.length) return false;


### PR DESCRIPTION
## Objetivo
Fechar enforcement de RBAC no frontend para todos os módulos principais do dashboard, alinhando visualização e acesso com os grupos de papéis do backend.

## Escopo
- expandido `apps/web/src/lib/rbac.ts` com grupos:
  - `FINANCIAL_ROLES`
  - `MANAGEMENT_ROLES`
  - `ACADEMIC_ROLES`
  - `FULL_ACCESS_ROLES`
- menu lateral + tabs mobile filtrados por permissão em `dashboard/layout.tsx`
- guarda de acesso por tela com fallback de "sem permissão" em:
  - `/dashboard`
  - `/dashboard/criancas`
  - `/dashboard/contratos`
  - `/dashboard/diario`
  - `/dashboard/coordenacao`
  - `/dashboard/rh`
  - `/dashboard/whatsapp`
  - `/dashboard/personalizacao`
  - `/dashboard/financeiro` (já existente, mantido)

## Validação
- `pnpm --filter web lint`
- `pnpm --filter web build`
- `pnpm --filter api lint`
- `pnpm --filter api test -- --runInBand --verbose src/billing/billing.service.spec.ts`
- `pnpm --filter api build`
