### PR TITLE
chore: gate verify e runbook de operação

### DIFF
--- a/docs/runbook-operacao.md
+++ b/docs/runbook-operacao.md
@@ -1,0 +1,56 @@
+# Runbook de Operação — LudiKids Workspace
+
+## 1) Pré-check rápido
+```bash
+pnpm verify
+```
+Esperado: lint/build web e api + teste billing verde.
+
+## 2) Deploy (VM 10.10.10.109)
+```bash
+cd /opt/ludikids-workspace
+git fetch origin
+git reset --hard origin/main
+docker compose --env-file .env -f infra/docker-compose.full.yml up -d --build api web caddy
+docker compose --env-file .env -f infra/docker-compose.full.yml ps
+```
+Esperado: `api` e `web` com status `healthy`.
+
+## 3) Smoke funcional (produção)
+- Login em `/login`
+- Navegação dashboard respeitando RBAC por perfil
+- Financeiro: abrir competência, carregar resumo/faturas/conciliação
+- Comunicação: processar regras (stub) sem erro
+
+## 4) Diagnóstico rápido
+### API logs
+```bash
+docker logs --tail 200 ludikids-api
+```
+### WEB logs
+```bash
+docker logs --tail 200 ludikids-web
+```
+### Caddy logs
+```bash
+docker logs --tail 200 ludikids-caddy
+```
+
+## 5) Incidentes comuns
+- **UI sem atualização após deploy**: limpar cache/service worker do navegador.
+- **401 em cascata**: validar `JWT_SECRET`, `JWT_REFRESH_SECRET`, `JWT_EXPIRES_IN`, `JWT_REFRESH_EXPIRES_IN`.
+- **CORS em produção**: conferir `WEB_ORIGIN` no `.env`.
+
+## 6) Rollback
+```bash
+cd /opt/ludikids-workspace
+git reflog --date=local -n 10
+git reset --hard <commit-anterior>
+docker compose --env-file .env -f infra/docker-compose.full.yml up -d --build api web caddy
+```
+
+## 7) Checklist de fechamento
+- [ ] `pnpm verify` passou
+- [ ] Deploy com containers `healthy`
+- [ ] Smoke funcional em produção ok
+- [ ] Sem erro novo em logs críticos

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:seed": "pnpm --filter api exec prisma db seed",
     "db:studio": "pnpm --filter api exec prisma studio",
     "lint": "pnpm -r --if-present lint",
-    "test": "pnpm -r --if-present test"
+    "test": "pnpm -r --if-present test",
+    "verify": "pnpm --filter web lint && pnpm --filter web build && pnpm --filter api lint && pnpm --filter api test -- --runInBand --verbose src/billing/billing.service.spec.ts && pnpm --filter api build"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Objetivo
Fechar base operacional com gate único de qualidade e runbook de operação para deploy/diagnóstico/rollback.

## O que foi feito
- adicionado script `verify` no root `package.json` com pipeline padrão:
  - web lint/build
  - api lint/test(building.spec)/build
- criado `docs/runbook-operacao.md` com:
  - pré-check
  - deploy na VM
  - smoke funcional
  - diagnóstico por logs
  - incidentes comuns
  - rollback
  - checklist de fechamento

## Validação
- `pnpm verify` executado com sucesso
